### PR TITLE
feat: fragment component

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,26 @@ Use [Vue 3's Fragment feature](https://v3.vuejs.org/guide/migration/fragments.ht
 
 ```vue
 <template>
-    <div v-frag> ⬅ This root element is unwrapped and removed on render!
+    <fragment> ⬅ This root element will not exist in the DOM
 
         <li>Element 1</li>
         <li>Element 2</li>
         <li>Element 3</li>
-    </div>
+    </fragment>
 </template>
+
+<script>
+import { Fragment } from 'vue-frag'
+
+export default {
+    components: {
+        Fragment
+    }
+}
+</script>
 ```
 
-👉 Try out a [demo in this CodePen](https://codepen.io/hirokiosame/pen/PoNVZbV)!
+👉 [Try it out on CodePen](https://codepen.io/hirokiosame/pen/PoNVZbV)!
 
 <sub>Support this project by ⭐️ starring and sharing it. [Follow me](https://github.com/privatenumber) to see what other cool projects I'm working on! ❤️</sub>
 
@@ -29,67 +39,87 @@ npm i vue-frag
 ```
 
 ## 🚦 Quick Setup
+You can either choose to use the _Component_ or _Directive_ API.
 
-#### Register globally
-Make it available anywhere in your Vue application.
+### Component API
+The Component API is designed to be used at the root of the template. It should feel intuitive to use and cover most use-cases.
 
-```js
-import frag from 'vue-frag';
-Vue.directive('frag', frag);
-```
-
-#### Register locally
-Explicitly register it to a component you want to use it in.
-
+Import `Fragment` and use it as the root element of your component:
 ```vue
-...
+<template>
+    <fragment>
+        Hello world!
+    </fragment>
+</template>
 
 <script>
-import frag from 'vue-frag';
+import { Fragment } from 'vue-frag'
 
 export default {
-    directives: {
-        frag
-    },
-
-    ...
-};
+    components: {
+        Fragment
+    }
+}
 </script>
 ```
 
-#### Prefer a component API?
-Create a `Fragment.vue` component:
+#### Register globally
+[Globally registering](https://vuejs.org/v2/guide/components-registration.html) the component lets you use it without needing to import it every time.
+```js
+import { Fragment } from 'vue-frag'
+
+Vue.component('Fragment', Fragment)
+```
+
+### Directive API
+Use the Directive API to have more nuanced control over placement. For example, if you want to unwrap the root node of a component on the usage-end.
+
+The Component API uses the Directive API under the hood.
 
 ```vue
 <template>
     <div v-frag>
-        <slot />
+        Hello world!
     </div>
 </template>
 
 <script>
-import frag from 'vue-frag';
+import frag from 'vue-frag'
 
 export default {
     directives: {
         frag
     }
-};
+}
 </script>
 ```
 
-And use it as a component:
-```vue
-<template>
-    <fragment>
-        No root element!
-    </fragment>
-</template>
+#### Register globally
+Make it available anywhere in your Vue application.
+
+```js
+import frag from 'vue-frag'
+
+Vue.directive('frag', frag)
 ```
 
 ## 👨🏻‍🏫 Examples
 
 #### Returning multiple root nodes <a href="https://codepen.io/hirokiosame/pen/PoNVZbV"><img src="https://img.shields.io/badge/codepen.io-demo-blue" valign="bottom"></a>
+Component API
+```vue
+<template>
+    <fragment> <!-- This element will be unwrapped -->
+
+        <div v-for="i in 10">
+            {{ i }}
+        </div>
+    </fragment>
+</template>
+```
+
+
+Directive API
 ```vue
 <template>
     <div v-frag> <!-- This element will be unwrapped -->
@@ -102,6 +132,8 @@ And use it as a component:
 ```
 
 #### Unwrapping the root node from a component
+Use the Directive API to unwrap the root node of a component.
+
 ```vue
 <template>
     <div>
@@ -115,7 +147,9 @@ And use it as a component:
 ```vue
 <template>
     <div v-frag>
-        <template v-if />
+        <template v-if="isShown">
+            Hello world!
+        </template>
     </div>
 </template>
 ```

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
 	},
 	"lint-staged": {
 		"*.{js,ts}": [
-			"eslint --fix",
+			"eslint",
+			"npm run build",
 			"jest --bail --findRelatedTests"
 		]
 	},

--- a/package.json
+++ b/package.json
@@ -32,13 +32,12 @@
 	},
 	"husky": {
 		"hooks": {
-			"pre-commit": "lint-staged"
+			"pre-commit": "npm run build && lint-staged"
 		}
 	},
 	"lint-staged": {
 		"*.{js,ts}": [
 			"eslint",
-			"npm run build",
 			"jest --bail --findRelatedTests"
 		]
 	},

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -11,68 +11,84 @@ const babelPlugin = babel({
 	],
 });
 
-const rollupConfig = {
-	input: 'src/frag.js',
-	plugins: [
-		babelPlugin,
+const nonMinifiedPlugins = [
+	babelPlugin,
 
-		// Strip comments
-		terser({
-			compress: false,
-			mangle: false,
-			format: {
-				beautify: true,
-			},
-		}),
+	// Strip comments
+	terser({
+		compress: false,
+		mangle: false,
+		format: {
+			beautify: true,
+		},
+	}),
 
-		filesize(),
-	],
-	output: [
-		{
+	filesize(),
+];
+
+const minifiedPlugins = [
+	babelPlugin,
+	terser(),
+];
+
+export default [
+	// ESM
+	{
+		input: 'src/index.esm.js',
+		plugins: nonMinifiedPlugins,
+		output: {
 			format: 'es',
 			file: 'dist/frag.esm.js',
 		},
-		{
-			format: 'cjs',
-			file: 'dist/frag.cjs.js',
-			exports: 'default',
-		},
-		{
-			format: 'umd',
-			file: 'dist/frag.js',
-			name: 'Frag',
-			exports: 'default',
-		},
-	],
-};
-
-const rollupConfigMin = {
-	input: 'src/frag.js',
-	plugins: [
-		babelPlugin,
-
-		terser(),
-	],
-	output: [
-		{
+	},
+	{
+		input: 'src/index.esm.js',
+		plugins: minifiedPlugins,
+		output: {
 			format: 'es',
 			file: 'dist/frag.esm.min.js',
 		},
-		{
+	},
+
+	// CJS
+	{
+		input: 'src/index.cjs.js',
+		plugins: nonMinifiedPlugins,
+		output: {
 			format: 'cjs',
-			file: 'dist/frag.cjs.min.js',
 			exports: 'default',
+			file: 'dist/frag.cjs.js',
 		},
-		{
+	},
+	{
+		input: 'src/index.cjs.js',
+		plugins: minifiedPlugins,
+		output: {
+			format: 'cjs',
+			exports: 'default',
+			file: 'dist/frag.cjs.min.js',
+		},
+	},
+
+	// UMD
+	{
+		input: 'src/index.cjs.js',
+		plugins: nonMinifiedPlugins,
+		output: {
 			format: 'umd',
-			file: 'dist/frag.min.js',
 			name: 'Frag',
 			exports: 'default',
+			file: 'dist/frag.js',
 		},
-	],
-};
-
-export default [
-	rollupConfig,
-	rollupConfigMin,
+	},
+	{
+		input: 'src/index.cjs.js',
+		plugins: minifiedPlugins,
+		output: {
+			format: 'umd',
+			name: 'Frag',
+			exports: 'default',
+			file: 'dist/frag.min.js',
+		},
+	},
 ];

--- a/src/fragment.js
+++ b/src/fragment.js
@@ -1,0 +1,18 @@
+import frag from './frag.js';
+
+export default {
+	directives: {
+		frag,
+	},
+	render(h) {
+		return h(
+			'div',
+			{
+				directives: [
+					{ name: 'frag' },
+				],
+			},
+			this.$slots.default,
+		);
+	},
+};

--- a/src/index.cjs.js
+++ b/src/index.cjs.js
@@ -1,0 +1,6 @@
+import Fragment from './fragment.js';
+import frag from './frag.js';
+
+frag.Fragment = Fragment;
+
+export default frag;

--- a/src/index.esm.js
+++ b/src/index.esm.js
@@ -1,0 +1,4 @@
+import Frag from './frag.js';
+
+export { default as Fragment } from './fragment.js';
+export default Frag;


### PR DESCRIPTION
I wanted to keep the module as small as possible, probably out of competitiveness to vue-fragment, but now, it is clear it cannot be smaller due to how stable and bug-proof it is.

I'm now open to adding a component API, which turned out to be a trivial addition in size (0.1 kB non minified).

It should be tree-shakable in ESM mode.