### PR TITLE
fix: `innerHTML` to handle empty fragment

### DIFF
--- a/src/frag.js
+++ b/src/frag.js
@@ -280,7 +280,7 @@ const frag = {
 			set(htmlString) {
 				const domify = document.createElement('div');
 				domify.innerHTML = htmlString;
-        			const hasPlaceholder = this.frag[0] === placeholder;
+				const hasPlaceholder = this.frag[0] === placeholder;
 				const oldNodesIndex = hasPlaceholder ? 0 : this.frag.length;
 
 				// Array.from makes a copy of the NodeList, which is live updating as we appendChild
@@ -291,7 +291,7 @@ const frag = {
 
 				const removedNodes = this.frag.splice(0, oldNodesIndex);
 				if (this.frag.length === 0 && removedNodes[0]) {
-				  addPlaceholder(this, removedNodes[0]);
+					addPlaceholder(this, removedNodes[0]);
 				}
 				domify.append(...removedNodes);
 			},

--- a/src/frag.js
+++ b/src/frag.js
@@ -278,22 +278,24 @@ const frag = {
 
 		Object.defineProperty(element, 'innerHTML', {
 			set(htmlString) {
-				const domify = document.createElement('div');
-				domify.innerHTML = htmlString;
-				const hasPlaceholder = this.frag[0] === placeholder;
-				const oldNodesIndex = hasPlaceholder ? 0 : this.frag.length;
-
-				// Array.from makes a copy of the NodeList, which is live updating as we appendChild
-				Array.from(domify.childNodes).forEach((node) => {
-					// eslint-disable-next-line unicorn/prefer-dom-node-append
-					this.appendChild(node);
-				});
-
-				const removedNodes = this.frag.splice(0, oldNodesIndex);
-				if (this.frag.length === 0 && removedNodes[0]) {
-					addPlaceholder(this, removedNodes[0]);
+				// If it has childrem (non-placeholder), remove them
+				if (this.frag[0] !== placeholder) {
+					this.frag.slice().forEach(
+						// eslint-disable-next-line unicorn/prefer-dom-node-remove
+						child => this.removeChild(child),
+					);
 				}
-				domify.append(...removedNodes);
+
+				if (htmlString) {
+					const domify = document.createElement('div');
+					domify.innerHTML = htmlString;
+
+					// Array.from makes a copy of the NodeList, which is live updating as we appendChild
+					Array.from(domify.childNodes).forEach((node) => {
+						// eslint-disable-next-line unicorn/prefer-dom-node-append
+						this.appendChild(node);
+					});
+				}
 			},
 			get() {
 				return '';

--- a/src/frag.js
+++ b/src/frag.js
@@ -280,7 +280,7 @@ const frag = {
 			set(htmlString) {
 				const domify = document.createElement('div');
 				domify.innerHTML = htmlString;
-        const hasPlaceholder = this.frag[0] === placeholder;
+        			const hasPlaceholder = this.frag[0] === placeholder;
 				const oldNodesIndex = hasPlaceholder ? 0 : this.frag.length;
 
 				// Array.from makes a copy of the NodeList, which is live updating as we appendChild
@@ -289,10 +289,10 @@ const frag = {
 					this.appendChild(node);
 				});
 
-        const removedNodes = this.frag.splice(0, oldNodesIndex);
-        if (this.frag.length === 0 && removedNodes[0]) {
-          addPlaceholder(this, removedNodes[0]);
-        }
+				const removedNodes = this.frag.splice(0, oldNodesIndex);
+				if (this.frag.length === 0 && removedNodes[0]) {
+				  addPlaceholder(this, removedNodes[0]);
+				}
 				domify.append(...removedNodes);
 			},
 			get() {

--- a/src/frag.js
+++ b/src/frag.js
@@ -280,8 +280,8 @@ const frag = {
 			set(htmlString) {
 				const domify = document.createElement('div');
 				domify.innerHTML = htmlString;
-
-				const oldNodesIndex = this.frag.length;
+        const hasPlaceholder = this.frag[0] === placeholder;
+				const oldNodesIndex = hasPlaceholder ? 0 : this.frag.length;
 
 				// Array.from makes a copy of the NodeList, which is live updating as we appendChild
 				Array.from(domify.childNodes).forEach((node) => {

--- a/src/frag.js
+++ b/src/frag.js
@@ -288,7 +288,12 @@ const frag = {
 					// eslint-disable-next-line unicorn/prefer-dom-node-append
 					this.appendChild(node);
 				});
-				domify.append(...this.frag.splice(0, oldNodesIndex));
+
+        const removedNodes = this.frag.splice(0, oldNodesIndex);
+        if (this.frag.length === 0 && removedNodes[0]) {
+          addPlaceholder(this, removedNodes[0]);
+        }
+				domify.append(...removedNodes);
 			},
 			get() {
 				return '';

--- a/test/vue-frag.spec.ts
+++ b/test/vue-frag.spec.ts
@@ -7,7 +7,10 @@ import { mount } from '@vue/test-utils';
 import { defineComponent } from '@vue/composition-api';
 import outdent from 'outdent';
 import frag from '..';
-import { dualMount, createMountTarget } from './utils';
+import {
+	dualMount,
+	createMountTarget,
+} from './utils';
 
 Vue.config.ignoredElements = ['app', 'frag'];
 
@@ -24,7 +27,7 @@ test('Nested frags', async () => {
 			frag,
 		},
 		beforeCreate() {
-      this.$options.components!.ChildComp = ChildComp;
+			this.$options.components!.ChildComp = ChildComp;
 		},
 	});
 
@@ -440,9 +443,7 @@ describe('Reactivity', () => {
 		wrapper.expectMatchingDom();
 
 		await wrapper.setData({ num: 3 });
-		expect(wrapper.frag.html()).toBe(
-			tpl(['A 1', 'A 2', 'A 3', 'B 1', 'B 2', 'B 3', 'C 1', 'C 2', 'C 3']),
-		);
+		expect(wrapper.frag.html()).toBe(tpl(['A 1', 'A 2', 'A 3', 'B 1', 'B 2', 'B 3', 'C 1', 'C 2', 'C 3']));
 		wrapper.expectMatchingDom();
 	});
 });
@@ -553,8 +554,7 @@ test('Parent nested v-if empty', async () => {
 	};
 
 	const ParentComp = {
-		template:
-      '<frag v-frag>Parent <child-comp v-if="shown" ref="child" /><div v-else>No Child</div></frag>',
+		template: '<frag v-frag>Parent <child-comp v-if="shown" ref="child" /><div v-else>No Child</div></frag>',
 
 		directives: {
 			frag,
@@ -730,11 +730,9 @@ test('child order change', async () => {
 
 	const tpl = (content: number) => `<app>${content}</app>`;
 
-	const wrapper = mount<
-    Vue & {
-      numbers: number[];
-    }
-  >(usage);
+	const wrapper = mount<Vue & {
+		numbers: number[];
+	}>(usage);
 
 	expect(wrapper.html()).toBe(tpl(123));
 
@@ -980,8 +978,7 @@ test('updating sibling node - removal - no nextSibling', async () => {
 	const usage = {
 		// Important that this is in one-line
 		// When breaking into multiple lines, it inserts a textNode in between and breaks reproduction
-		template:
-      '<app><span v-if="isVisible" /><child :show="isVisible" /><span v-if="isVisible" /></app>',
+		template: '<app><span v-if="isVisible" /><child :show="isVisible" /><span v-if="isVisible" /></app>',
 
 		components: {
 			Child,
@@ -1186,41 +1183,4 @@ test('nested fragments', async () => {
 	</app>
 	`);
 	wrapper.expectMatchingDom();
-});
-
-// #67
-test('Set innerHTML of empty fragment', async () => {
-	const usage = {
-		template: `
-        <div>
-          <div v-frag ref="fragment" />
-        </div>
-        `,
-		directives: { frag },
-		data() {
-			return {
-				html: '',
-			};
-		},
-		watch: {
-			html() {
-				this.$refs.fragment.innerHTML = this.html;
-			},
-		},
-	};
-
-	const wrapper = mount(usage);
-
-	await wrapper.setData({ html: '<span>first</span><span>second</span>' });
-	expect(wrapper.html()).toBe('<div><span>first</span><span>second</span></div>');
-
-	await wrapper.setData({ html: '' });
-	expect(wrapper.html()).toBe(outdent`
-  <div>
-    <!---->
-  </div>`);
-
-	// Set innerHTML to empty string, then set innerHTML
-	await wrapper.setData({ html: '<span>first</span><span>second</span>' });
-	expect(wrapper.html()).toBe('<div><span>first</span><span>second</span></div>');
 });

--- a/test/vue-frag.spec.ts
+++ b/test/vue-frag.spec.ts
@@ -1184,3 +1184,40 @@ test('nested fragments', async () => {
 	`);
 	wrapper.expectMatchingDom();
 });
+
+// #67
+test('Set innerHTML of empty fragment', async () => {
+	const forTest = {
+		template: `
+        <div>
+          <div v-frag ref="fragment" />
+        </div>
+        `,
+		directives: { frag },
+		data() {
+			return {
+				html: '',
+			};
+		},
+		watch: {
+			html() {
+				this.$refs.fragment.innerHTML = this.html;
+			},
+		},
+	};
+
+	const wrapper = mount(forTest);
+
+	await wrapper.setData({ html: '<span>first</span><span>second</span>' });
+	expect(wrapper.html()).toBe('<div><span>first</span><span>second</span></div>');
+
+	await wrapper.setData({ html: '' });
+	expect(wrapper.html()).toBe(outdent`
+  <div>
+    <!---->
+  </div>`);
+
+	// Set innerHTML to empty string, then set innerHTML
+	await wrapper.setData({ html: '<span>first</span><span>second</span>' });
+	expect(wrapper.html()).toBe('<div><span>first</span><span>second</span></div>');
+});

--- a/test/vue-frag.spec.ts
+++ b/test/vue-frag.spec.ts
@@ -1189,12 +1189,8 @@ test('nested fragments', async () => {
 test('Set innerHTML of empty fragment', async () => {
 	// The code below is not a common use-case.
 	// It is written only for testing. Avoid direct DOM manipulation whenever possible.
-	const forTest = {
-		template: `
-        <div>
-          <div v-frag ref="fragment" />
-        </div>
-        `,
+	const usage = defineComponent({
+		template: '<app><frag v-frag ref="fragment" /></app>',
 		directives: { frag },
 		data() {
 			return {
@@ -1203,23 +1199,35 @@ test('Set innerHTML of empty fragment', async () => {
 		},
 		watch: {
 			html() {
-				this.$refs.fragment.innerHTML = this.html;
+				(this.$refs.fragment as HTMLElement).innerHTML = this.html;
 			},
 		},
-	};
+	});
 
-	const wrapper = mount(forTest);
+	const wrapper = mount(usage);
+	expect(wrapper.html()).toBe(
+		outdent`
+		<app>
+		  <!---->
+		</app>
+		`,
+	);
 
-	await wrapper.setData({ html: '<span>first</span><span>second</span>' });
-	expect(wrapper.html()).toBe('<div><span>first</span><span>second</span></div>');
+	const html = '<span>first</span><span>second</span>';
+	const output = '<app><span>first</span><span>second</span></app>';
+
+	await wrapper.setData({ html });
+	expect(wrapper.html()).toBe(output);
 
 	await wrapper.setData({ html: '' });
-	expect(wrapper.html()).toBe(outdent`
-  <div>
-    <!---->
-  </div>`);
+	expect(wrapper.html()).toBe(
+		outdent`
+		<app>
+		  <!---->
+		</app>
+		`,
+	);
 
-	// Set innerHTML to empty string, then set innerHTML
-	await wrapper.setData({ html: '<span>first</span><span>second</span>' });
-	expect(wrapper.html()).toBe('<div><span>first</span><span>second</span></div>');
+	await wrapper.setData({ html });
+	expect(wrapper.html()).toBe(output);
 });

--- a/test/vue-frag.spec.ts
+++ b/test/vue-frag.spec.ts
@@ -7,10 +7,7 @@ import { mount } from '@vue/test-utils';
 import { defineComponent } from '@vue/composition-api';
 import outdent from 'outdent';
 import frag from '..';
-import {
-	dualMount,
-	createMountTarget,
-} from './utils';
+import { dualMount, createMountTarget } from './utils';
 
 Vue.config.ignoredElements = ['app', 'frag'];
 
@@ -27,7 +24,7 @@ test('Nested frags', async () => {
 			frag,
 		},
 		beforeCreate() {
-			this.$options.components!.ChildComp = ChildComp;
+      this.$options.components!.ChildComp = ChildComp;
 		},
 	});
 
@@ -443,7 +440,9 @@ describe('Reactivity', () => {
 		wrapper.expectMatchingDom();
 
 		await wrapper.setData({ num: 3 });
-		expect(wrapper.frag.html()).toBe(tpl(['A 1', 'A 2', 'A 3', 'B 1', 'B 2', 'B 3', 'C 1', 'C 2', 'C 3']));
+		expect(wrapper.frag.html()).toBe(
+			tpl(['A 1', 'A 2', 'A 3', 'B 1', 'B 2', 'B 3', 'C 1', 'C 2', 'C 3']),
+		);
 		wrapper.expectMatchingDom();
 	});
 });
@@ -554,7 +553,8 @@ test('Parent nested v-if empty', async () => {
 	};
 
 	const ParentComp = {
-		template: '<frag v-frag>Parent <child-comp v-if="shown" ref="child" /><div v-else>No Child</div></frag>',
+		template:
+      '<frag v-frag>Parent <child-comp v-if="shown" ref="child" /><div v-else>No Child</div></frag>',
 
 		directives: {
 			frag,
@@ -730,9 +730,11 @@ test('child order change', async () => {
 
 	const tpl = (content: number) => `<app>${content}</app>`;
 
-	const wrapper = mount<Vue & {
-		numbers: number[];
-	}>(usage);
+	const wrapper = mount<
+    Vue & {
+      numbers: number[];
+    }
+  >(usage);
 
 	expect(wrapper.html()).toBe(tpl(123));
 
@@ -978,7 +980,8 @@ test('updating sibling node - removal - no nextSibling', async () => {
 	const usage = {
 		// Important that this is in one-line
 		// When breaking into multiple lines, it inserts a textNode in between and breaks reproduction
-		template: '<app><span v-if="isVisible" /><child :show="isVisible" /><span v-if="isVisible" /></app>',
+		template:
+      '<app><span v-if="isVisible" /><child :show="isVisible" /><span v-if="isVisible" /></app>',
 
 		components: {
 			Child,
@@ -1183,4 +1186,41 @@ test('nested fragments', async () => {
 	</app>
 	`);
 	wrapper.expectMatchingDom();
+});
+
+// #67
+test('Set innerHTML of empty fragment', async () => {
+	const usage = {
+		template: `
+        <div>
+          <div v-frag ref="fragment" />
+        </div>
+        `,
+		directives: { frag },
+		data() {
+			return {
+				html: '',
+			};
+		},
+		watch: {
+			html() {
+				this.$refs.fragment.innerHTML = this.html;
+			},
+		},
+	};
+
+	const wrapper = mount(usage);
+
+	await wrapper.setData({ html: '<span>first</span><span>second</span>' });
+	expect(wrapper.html()).toBe('<div><span>first</span><span>second</span></div>');
+
+	await wrapper.setData({ html: '' });
+	expect(wrapper.html()).toBe(outdent`
+  <div>
+    <!---->
+  </div>`);
+
+	// Set innerHTML to empty string, then set innerHTML
+	await wrapper.setData({ html: '<span>first</span><span>second</span>' });
+	expect(wrapper.html()).toBe('<div><span>first</span><span>second</span></div>');
 });

--- a/test/vue-frag.spec.ts
+++ b/test/vue-frag.spec.ts
@@ -1187,6 +1187,8 @@ test('nested fragments', async () => {
 
 // #67
 test('Set innerHTML of empty fragment', async () => {
+	// The code below is not a common use-case.
+	// It is written only for testing. Avoid direct DOM manipulation whenever possible.
 	const forTest = {
 		template: `
         <div>


### PR DESCRIPTION
This PR is about two issues.

1. When `innerHTML` is set with placeholder, `oldNodesIndex` becomes `1`.
Then when `appendChild` is called, the placeholder is removed.
So when `splice` is called, it removes the first node instead of the placeholder.
Therefore, only nodes excluding the first node are displayed.

2. Set `innerHTML` to an empty string and then try to set it again, the set will fail with `lastChild` being `undefined` in the `appendChild` method because the frag is empty.