### PR TITLE
fix: support `keep-alive`

### DIFF
--- a/src/frag.js
+++ b/src/frag.js
@@ -176,11 +176,7 @@ function insertBefore(
 	insertNode,
 	insertBeforeNode,
 ) {
-	if (
-		insertNode.nodeType === Node.ELEMENT_NODE
-		&& $fakeParent in insertNode
-		&& insertNode.parentElement
-	) {
+	if (isFrag(this) && insertNode.parentElement) {
 		return insertNode;
 	}
 
@@ -223,11 +219,7 @@ function insertBefore(
 }
 
 function appendChild(node) {
-	if (
-		node.nodeType === Node.ELEMENT_NODE
-		&& $fakeParent in node
-		&& node.parentElement
-	) {
+	if ($fakeParent in node && node.parentElement) {
 		return node;
 	}
 

--- a/src/frag.js
+++ b/src/frag.js
@@ -176,8 +176,14 @@ function insertBefore(
 	insertNode,
 	insertBeforeNode,
 ) {
-	if (insertNode.parentElement && insertNode.nodeType === Node.ELEMENT_NODE && $fakeParent in insertNode) return insertNode
-	
+	if (
+		insertNode.parentElement
+		&& insertNode.nodeType === Node.ELEMENT_NODE
+		&& $fakeParent in insertNode
+	) {
+		return insertNode;
+	}
+
 	// Should this be leaf nodes?
 	const insertNodes = insertNode.frag || [insertNode];
 
@@ -217,8 +223,14 @@ function insertBefore(
 }
 
 function appendChild(node) {
-	if (node.parentElement && node.nodeType === Node.ELEMENT_NODE && $fakeParent in node) return node
-	
+	if (
+		node.parentElement
+		&& node.nodeType === Node.ELEMENT_NODE
+		&& $fakeParent in node
+	) {
+		return node;
+	}
+
 	const { frag } = this;
 	const lastChild = frag[frag.length - 1];
 

--- a/src/frag.js
+++ b/src/frag.js
@@ -177,9 +177,9 @@ function insertBefore(
 	insertBeforeNode,
 ) {
 	if (
-		insertNode.parentElement
-		&& insertNode.nodeType === Node.ELEMENT_NODE
+		insertNode.nodeType === Node.ELEMENT_NODE
 		&& $fakeParent in insertNode
+		&& insertNode.parentElement
 	) {
 		return insertNode;
 	}
@@ -224,9 +224,9 @@ function insertBefore(
 
 function appendChild(node) {
 	if (
-		node.parentElement
-		&& node.nodeType === Node.ELEMENT_NODE
+		node.nodeType === Node.ELEMENT_NODE
 		&& $fakeParent in node
+		&& node.parentElement
 	) {
 		return node;
 	}

--- a/src/frag.js
+++ b/src/frag.js
@@ -219,7 +219,13 @@ function insertBefore(
 }
 
 function appendChild(node) {
-	if ($fakeParent in node && node.parentElement) {
+	if (
+		// Parent already patched
+		node[$fakeParent] === this
+
+		// Previously inserted (reinserted via keep-alive)
+		&& node.parentElement
+	) {
 		return node;
 	}
 

--- a/src/frag.js
+++ b/src/frag.js
@@ -176,6 +176,8 @@ function insertBefore(
 	insertNode,
 	insertBeforeNode,
 ) {
+	if (insertNode.parentElement && insertNode.nodeType === Node.ELEMENT_NODE && $fakeParent in insertNode) return insertNode
+	
 	// Should this be leaf nodes?
 	const insertNodes = insertNode.frag || [insertNode];
 
@@ -215,6 +217,8 @@ function insertBefore(
 }
 
 function appendChild(node) {
+	if (node.parentElement && node.nodeType === Node.ELEMENT_NODE && $fakeParent in node) return node
+	
 	const { frag } = this;
 	const lastChild = frag[frag.length - 1];
 

--- a/test/vue-frag.spec.ts
+++ b/test/vue-frag.spec.ts
@@ -1231,3 +1231,47 @@ test('Set innerHTML of empty fragment', async () => {
 	await wrapper.setData({ html });
 	expect(wrapper.html()).toBe(output);
 });
+
+test('keep-alive', async () => {
+	const usage = {
+		template: `
+			<app>
+				<frag v-frag>
+					<keep-alive>
+						<component :is="children[index]"></component>
+					</keep-alive>
+				</frag>
+			</app>
+		`,
+		directives: { frag },
+		components: {
+			A: { template: '<div>A</div>' },
+			B: { template: '<div>B</div>' },
+			C: { template: '<div>C</div>' },
+		},
+		data() {
+			return {
+				index: 0,
+				children: ['A', 'B', 'A', 'C', 'A'],
+			};
+		},
+	};
+
+	const wrapper = dualMount(usage);
+	expect(wrapper.frag.html()).toBe('<app>\n  <div>A</div>\n</app>');
+
+	await wrapper.setData({ index: 1 });
+	expect(wrapper.frag.html()).toBe('<app>\n  <div>B</div>\n</app>');
+
+	await wrapper.setData({ index: 2 });
+	expect(wrapper.frag.html()).toBe('<app>\n  <div>A</div>\n</app>');
+
+	await wrapper.setData({ index: 3 });
+	expect(wrapper.frag.html()).toBe('<app>\n  <div>C</div>\n</app>');
+
+	await wrapper.setData({ index: 4 });
+	expect(wrapper.frag.html()).toBe('<app>\n  <div>A</div>\n</app>');
+
+	await wrapper.setData({ index: 5 });
+	expect(wrapper.frag.html()).toBe('<app>\n  <!---->\n</app>');
+});

--- a/test/vue-frag.spec.ts
+++ b/test/vue-frag.spec.ts
@@ -1235,13 +1235,13 @@ test('Set innerHTML of empty fragment', async () => {
 test('keep-alive', async () => {
 	const usage = {
 		template: `
-			<app>
-				<frag v-frag>
-					<keep-alive>
-						<component :is="children[index]"></component>
-					</keep-alive>
-				</frag>
-			</app>
+		<app>
+			<frag v-frag>
+				<keep-alive>
+					<component :is="component"></component>
+				</keep-alive>
+			</frag>
+		</app>
 		`,
 		directives: { frag },
 		components: {
@@ -1251,27 +1251,32 @@ test('keep-alive', async () => {
 		},
 		data() {
 			return {
-				index: 0,
-				children: ['A', 'B', 'A', 'C', 'A'],
+				component: 'A',
 			};
 		},
 	};
 
 	const wrapper = dualMount(usage);
 	expect(wrapper.frag.html()).toBe('<app>\n  <div>A</div>\n</app>');
+	wrapper.expectMatchingDom();
 
-	await wrapper.setData({ index: 1 });
+	await wrapper.setData({ component: 'B' });
 	expect(wrapper.frag.html()).toBe('<app>\n  <div>B</div>\n</app>');
+	wrapper.expectMatchingDom();
 
-	await wrapper.setData({ index: 2 });
+	await wrapper.setData({ component: 'A' });
 	expect(wrapper.frag.html()).toBe('<app>\n  <div>A</div>\n</app>');
+	wrapper.expectMatchingDom();
 
-	await wrapper.setData({ index: 3 });
+	await wrapper.setData({ component: 'C' });
 	expect(wrapper.frag.html()).toBe('<app>\n  <div>C</div>\n</app>');
+	wrapper.expectMatchingDom();
 
-	await wrapper.setData({ index: 4 });
+	await wrapper.setData({ component: 'A' });
 	expect(wrapper.frag.html()).toBe('<app>\n  <div>A</div>\n</app>');
+	wrapper.expectMatchingDom();
 
-	await wrapper.setData({ index: 5 });
+	await wrapper.setData({ component: '' });
 	expect(wrapper.frag.html()).toBe('<app>\n  <!---->\n</app>');
+	wrapper.expectMatchingDom();
 });

--- a/test/vue-frag.spec.ts
+++ b/test/vue-frag.spec.ts
@@ -1233,7 +1233,7 @@ test('Set innerHTML of empty fragment', async () => {
 });
 
 // #61
-test('keep-alive', async () => {
+test('keep-alive - appendChild', async () => {
 	const usage = {
 		template: `
 		<app>
@@ -1279,5 +1279,55 @@ test('keep-alive', async () => {
 
 	await wrapper.setData({ component: '' });
 	expect(wrapper.frag.html()).toBe('<app>\n  <!---->\n</app>');
+	wrapper.expectMatchingDom();
+});
+
+// #61 2
+test('keep-alive - insertBefore', async () => {
+	const usage = {
+		template: `
+		<app>
+			<frag v-frag>
+				<keep-alive>
+					<component :is="component"></component>
+				</keep-alive>1
+			</frag>
+		</app>
+		`,
+		directives: { frag },
+		components: {
+			A: { template: '<div>A</div>' },
+			B: { template: '<div>B</div>' },
+			C: { template: '<div>C</div>' },
+		},
+		data() {
+			return {
+				component: 'A',
+			};
+		},
+	};
+
+	const wrapper = dualMount(usage);
+	expect(wrapper.frag.html()).toBe('<app>\n  <div>A</div>1\n</app>');
+	wrapper.expectMatchingDom();
+
+	await wrapper.setData({ component: 'B' });
+	expect(wrapper.frag.html()).toBe('<app>\n  <div>B</div>1\n</app>');
+	wrapper.expectMatchingDom();
+
+	await wrapper.setData({ component: 'A' });
+	expect(wrapper.frag.html()).toBe('<app>\n  <div>A</div>1\n</app>');
+	wrapper.expectMatchingDom();
+
+	await wrapper.setData({ component: 'C' });
+	expect(wrapper.frag.html()).toBe('<app>\n  <div>C</div>1\n</app>');
+	wrapper.expectMatchingDom();
+
+	await wrapper.setData({ component: 'A' });
+	expect(wrapper.frag.html()).toBe('<app>\n  <div>A</div>1\n</app>');
+	wrapper.expectMatchingDom();
+
+	await wrapper.setData({ component: '' });
+	expect(wrapper.frag.html()).toBe('<app>\n  <!---->1\n</app>');
 	wrapper.expectMatchingDom();
 });

--- a/test/vue-frag.spec.ts
+++ b/test/vue-frag.spec.ts
@@ -1232,6 +1232,7 @@ test('Set innerHTML of empty fragment', async () => {
 	expect(wrapper.html()).toBe(output);
 });
 
+// #61
 test('keep-alive', async () => {
 	const usage = {
 		template: `


### PR DESCRIPTION
The issue #61 is caused by the fact that `insertBefore`/`appendChild` methods are called twice on [inserting reactivated components](https://github.com/vuejs/vue/blob/a9ca2d85193e435e668ba25ace481bfb176b0c6e/src/core/vdom/patch.ts#L198-L205).

The solution I came to was to skip the second insert. These "expected" and "non-expected" (reactivated) nodes are almost similar, except the `parentElement` property, which is `null` for the first inserted node and defined for the reactivated one. The rest part of the expression prevents skipping text and comment nodes which seem to be always connected to a `document`.